### PR TITLE
Handle OpenID connect errors more clearly

### DIFF
--- a/src/core/handlers/handleLoginRouting.ts
+++ b/src/core/handlers/handleLoginRouting.ts
@@ -35,6 +35,8 @@ export default async function handleLoginRouting(toState: State, store: Store) {
       });
       store.checkToken();
       return Promise.reject({ redirect: { name: 'home' } });
+    } else if (toState.params.error) {
+      alert(JSON.parse(atob(toState.params.error)).msg);
     }
     // if no token is set, find the login method
     const loginMethod = await store.loadLoginMethod();


### PR DESCRIPTION
Currently, whenever the OpenID connect login flow encounters an error, the user will be redirected to the login again. The error message is included in the response (as base64-encoded JSON in the `error` query parameter), but is ignored. This can make it very opaque why the user is redirected to the login again (Insufficient permissions? Not allowed to authenticate? No matching role? Broken OpenID connect configuration?)

It would be nice that, rather than forwarding, the error would be shown to the user in a window, with buttons "go back" and "log in" (depending on the context).

This PR does alert the error message in a very rudimentary fashion, but it needs to be more polished.